### PR TITLE
RestRequestProcessor signature changes

### DIFF
--- a/src/SimpleRestServices/Core/Exceptions/BadWebRequestException.cs
+++ b/src/SimpleRestServices/Core/Exceptions/BadWebRequestException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace JSIStudios.SimpleRESTServices.Core.Exceptions
+{
+    public class BadWebRequestException : Exception
+    {
+        public BadWebRequestException(string message)
+            : base(message)
+        {
+        }
+
+        public BadWebRequestException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/SimpleRestServices/Core/Exceptions/HttpHeaderNotFoundException.cs
+++ b/src/SimpleRestServices/Core/Exceptions/HttpHeaderNotFoundException.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace JSIStudios.SimpleRESTServices.Core.Exceptions
+{
+    public class HttpHeaderNotFoundException : Exception
+    {
+        public string Name { get; set; }
+        public HttpHeaderNotFoundException(string name, string message)
+            : base(message)
+        {
+            Name = name;
+        }
+
+        public HttpHeaderNotFoundException(string name)
+        {
+            Name = name;
+        }
+
+        public HttpHeaderNotFoundException()
+        {
+        }
+    }
+}

--- a/src/SimpleRestServices/Core/Exceptions/HttpResourceNotFoundException.cs
+++ b/src/SimpleRestServices/Core/Exceptions/HttpResourceNotFoundException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace JSIStudios.SimpleRESTServices.Core.Exceptions
+{
+    public class HttpResourceNotFoundException : Exception
+    {
+        public HttpResourceNotFoundException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/SimpleRestServices/Core/Exceptions/HttpResourceNotModifiedException.cs
+++ b/src/SimpleRestServices/Core/Exceptions/HttpResourceNotModifiedException.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace JSIStudios.SimpleRESTServices.Core.Exceptions
+{
+    public class HttpResourceNotModifiedException : Exception
+    {
+        public HttpResourceNotModifiedException()
+        {
+        }
+    }
+}

--- a/src/SimpleRestServices/Core/IRequestProcessor.cs
+++ b/src/SimpleRestServices/Core/IRequestProcessor.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Collections.Specialized;
+using JSIStudios.SimpleRESTServices.Server.EventArgs;
 
-namespace JSIStudios.SimpleRESTServices.Server
+namespace JSIStudios.SimpleRESTServices.Core
 {
     public interface IRequestProcessor
     {
@@ -14,14 +15,5 @@ namespace JSIStudios.SimpleRESTServices.Server
 
         TResult Execute<TResult>(Func<Guid, TResult> callBack);
         TResult Execute<TResult>(Func<Guid, TResult> callBack, NameValueCollection responseHeaders);
-
-        void ExecuteSecure(Action<Guid> callBack);
-        void ExecuteSecure(Action<Guid> callBack, string controllerName);
-        void ExecuteSecure(Action<Guid> callBack, string controllerName, NameValueCollection responseHeaders);
-
-        TResult ExecuteSecure<TResult>(Func<Guid, TResult> callBack);
-        TResult ExecuteSecure<TResult>(Func<Guid, TResult> callBack, string controllerName);
-        TResult ExecuteSecure<TResult>(Func<Guid, TResult> callBack, string controllerName, NameValueCollection responseHeaders);
-
     }
 }

--- a/src/SimpleRestServices/Properties/AssemblyInfo.cs
+++ b/src/SimpleRestServices/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.1.0")]
-[assembly: AssemblyFileVersion("1.0.1.0")]
+[assembly: AssemblyVersion("1.0.3.0")]
+[assembly: AssemblyFileVersion("1.0.3.0")]

--- a/src/SimpleRestServices/Server/EventArgs/RESTRequestCompletedEventArgs.cs
+++ b/src/SimpleRestServices/Server/EventArgs/RESTRequestCompletedEventArgs.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace JSIStudios.SimpleRESTServices.Server.EventArgs
+{
+    public class RESTRequestCompletedEventArgs : System.EventArgs
+    {
+        public Guid RequestId { get; private set; }
+
+        public object Response { get; private set; }
+
+        public long ExecutionTime { get; private set; }
+
+        public RESTRequestCompletedEventArgs(Guid requestId, object response, long exectionTime)
+            : base()
+        {
+            RequestId = requestId;
+            Response = response;
+            ExecutionTime = exectionTime;
+
+        }
+    }
+}

--- a/src/SimpleRestServices/Server/EventArgs/RESTRequestErrorEventArgs.cs
+++ b/src/SimpleRestServices/Server/EventArgs/RESTRequestErrorEventArgs.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace JSIStudios.SimpleRESTServices.Server.EventArgs
+{
+    public class RESTRequestErrorEventArgs : System.EventArgs
+    {
+        public Guid RequestId { get; private set; }
+
+        public Exception Error { get; private set; }
+
+        public RESTRequestErrorEventArgs(Guid requestId, Exception error)
+            : base()
+        {
+            RequestId = requestId;
+            Error = error;
+        }
+    }
+}

--- a/src/SimpleRestServices/Server/EventArgs/RESTRequestStartedEventArgs.cs
+++ b/src/SimpleRestServices/Server/EventArgs/RESTRequestStartedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace JSIStudios.SimpleRESTServices.Server.EventArgs
+{
+    public class RESTRequestStartedEventArgs : System.EventArgs
+    {
+        public Guid RequestId { get; private set; }
+
+        public string Request { get; private set; }
+
+        public RESTRequestStartedEventArgs(Guid requestId, string request)
+            : base()
+        {
+            RequestId = requestId;
+            Request = request;
+        }
+    }
+}

--- a/src/SimpleRestServices/SimpleRestServices.csproj
+++ b/src/SimpleRestServices/SimpleRestServices.csproj
@@ -60,10 +60,17 @@
     <Compile Include="Core\ITextCleaner.cs" />
     <Compile Include="Core\IRetryLogic.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Core\Exceptions\BadWebRequestException.cs" />
     <Compile Include="Server\FullHtmlTagCleaner.cs" />
     <Compile Include="Server\HtmlTagReplacerAndCleaner.cs" />
-    <Compile Include="Server\IRequestProcessor.cs" />
+    <Compile Include="Core\IRequestProcessor.cs" />
+    <Compile Include="Core\Exceptions\HttpHeaderNotFoundException.cs" />
+    <Compile Include="Core\Exceptions\HttpResourceNotFoundException.cs" />
+    <Compile Include="Core\Exceptions\HttpResourceNotModifiedException.cs" />
+    <Compile Include="Server\EventArgs\RESTRequestCompletedEventArgs.cs" />
+    <Compile Include="Server\EventArgs\RESTRequestErrorEventArgs.cs" />
     <Compile Include="Server\RESTRequestProcessor.cs" />
+    <Compile Include="Server\EventArgs\RESTRequestStartedEventArgs.cs" />
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>


### PR DESCRIPTION
Moved the custom EventArgs and Exception to their folder structure and removed the ExecuteSecure methods (They will be added back in a future release on a new IRestProcessor implementation)
