### PR TITLE
Fixed some exception that were not handled if the RawBody was null in the JsonRESTService class.

### DIFF
--- a/src/SimpleRestServices/Client/Response.cs
+++ b/src/SimpleRestServices/Client/Response.cs
@@ -28,27 +28,4 @@ namespace JSIStudios.SimpleRESTServices.Client
         {
         }
     }
-
-    [Serializable]
-    public class Response<T> : Response
-    {
-        public T Data { get; private set; }
-
-        public Response(int responseCode, string status, T data, IList<HttpHeader> headers, string rawBody)
-            : base(responseCode, status, headers, rawBody)
-        {
-            Data = data;
-        }
-
-        public Response(HttpStatusCode statusCode, T data, IList<HttpHeader> headers, string rawBody)
-            : this((int)statusCode, statusCode.ToString(), data, headers, rawBody)
-        {
-        }
-
-        public Response(Response baseResponse, T data)
-            : this((baseResponse == null) ? default(int) : baseResponse.StatusCode,
-                (baseResponse == null) ? null : baseResponse.Status, data,
-                (baseResponse == null) ? null : baseResponse.Headers,
-                (baseResponse == null) ? null : baseResponse.RawBody) { }
-    }
 }

--- a/src/SimpleRestServices/Client/ResponseOfT.cs
+++ b/src/SimpleRestServices/Client/ResponseOfT.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+
+namespace JSIStudios.SimpleRESTServices.Client
+{
+    [Serializable]
+    public class Response<T> : Response
+    {
+        public T Data { get; private set; }
+
+        public Response(int responseCode, string status, T data, IList<HttpHeader> headers, string rawBody)
+            : base(responseCode, status, headers, rawBody)
+        {
+            Data = data;
+        }
+
+        public Response(HttpStatusCode statusCode, T data, IList<HttpHeader> headers, string rawBody)
+            : this((int)statusCode, statusCode.ToString(), data, headers, rawBody)
+        {
+        }
+
+        public Response(Response baseResponse, T data)
+            : this((baseResponse == null) ? default(int) : baseResponse.StatusCode,
+                (baseResponse == null) ? null : baseResponse.Status, data,
+                (baseResponse == null) ? null : baseResponse.Headers,
+                (baseResponse == null) ? null : baseResponse.RawBody) { }
+    }
+}

--- a/src/SimpleRestServices/Properties/AssemblyInfo.cs
+++ b/src/SimpleRestServices/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.3.0")]
-[assembly: AssemblyFileVersion("1.0.3.0")]
+[assembly: AssemblyVersion("1.0.4.0")]
+[assembly: AssemblyFileVersion("1.0.4.0")]

--- a/src/SimpleRestServices/SimpleRestServices.csproj
+++ b/src/SimpleRestServices/SimpleRestServices.csproj
@@ -48,6 +48,7 @@
   <ItemGroup>
     <Compile Include="Client\HttpHeader.cs" />
     <Compile Include="Client\HttpMethod.cs" />
+    <Compile Include="Client\ResponseOfT.cs" />
     <Compile Include="Core\IRestService.cs" />
     <Compile Include="Core\IUrlBuilder.cs" />
     <Compile Include="Core\IRequestLogger.cs" />


### PR DESCRIPTION
- Fixed some exception that were not handled if the RawBody was null in the JsonRESTService class.
- Moved all logic in the JsonRestService's main Execute method into the try catch and added a sub try catch inside the outter catch block.  This is so the logger ALWAYS fires.  
- Also added new constructor options.
- Moved the **Response<T>** object to its own class file **ResponseOfT.cs**
