### PR TITLE
Check for nulls and empty strings when JSON serializing and deserializing

### DIFF
--- a/src/SimpleRestServices/Client/Json/JsonStringSerializer.cs
+++ b/src/SimpleRestServices/Client/Json/JsonStringSerializer.cs
@@ -7,6 +7,9 @@ namespace JSIStudios.SimpleRESTServices.Client.Json
     {
         public T Deserialize<T>(string content)
         {
+            if (string.IsNullOrWhiteSpace(content))
+                return default(T);
+
             try
             {
                 return JsonConvert.DeserializeObject<T>(content,
@@ -27,7 +30,9 @@ namespace JSIStudios.SimpleRESTServices.Client.Json
 
         public string Serialize<T>(T obj)
         {
-            
+            if (Equals(obj, default(T)))
+                return null;
+
             try
             {
                 return JsonConvert.SerializeObject(obj,

--- a/src/Testing/UnitTests/Client/Json/JsonStringSerializerTests.cs
+++ b/src/Testing/UnitTests/Client/Json/JsonStringSerializerTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Text;
+using System.Collections.Generic;
+using System.Linq;
+using JSIStudios.SimpleRESTServices.Client;
+using JSIStudios.SimpleRESTServices.Client.Json;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace JSIStudios.SimpleRestServices.Testing.UnitTests.Client.Json
+{
+    [TestClass]
+    public class JsonStringSerializerTests
+    {
+        [TestMethod]
+        public void DeserializeNullStringToNull()
+        {
+            IStringSerializer serializer = new JsonStringSerializer();
+            Assert.IsNull(serializer.Deserialize<object>(null));
+        }
+
+        [TestMethod]
+        public void DeserializeEmptyStringToNull()
+        {
+            IStringSerializer serializer = new JsonStringSerializer();
+            Assert.IsNull(serializer.Deserialize<object>(string.Empty));
+        }
+
+
+        [TestMethod]
+        public void SerializeNullObjectToNullString()
+        {
+            IStringSerializer serializer = new JsonStringSerializer();
+            Assert.IsNull(serializer.Serialize<object>(null));
+        }
+    }
+}

--- a/src/Testing/UnitTests/UnitTests.csproj
+++ b/src/Testing/UnitTests/UnitTests.csproj
@@ -45,6 +45,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Client\Json\JsonStringSerializerTests.cs" />
     <Compile Include="Client\UrlBuilderTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
Added null and empty string checks to the serialize/deserialize methods in JsonStringSerializer and added a couple of unit tests to verify.
