### PR TITLE
Create a new static readonly string JsonContentType for the "application/json" string literal

### DIFF
--- a/src/SimpleRestServices/Client/Json/JsonRequestSettings.cs
+++ b/src/SimpleRestServices/Client/Json/JsonRequestSettings.cs
@@ -2,10 +2,12 @@
 {
     public class JsonRequestSettings : RequestSettings
     {
+        public static readonly string JsonContentType = "application/json";
+
         public JsonRequestSettings()
         {
-            ContentType = "application/json";
-            Accept = "application/json";
+            ContentType = JsonContentType;
+            Accept = JsonContentType;
         }
     }
 }


### PR DESCRIPTION
Previously users wanting access to the string literal "application/json" needed to do one of the following:
- Embed the string literal `"application/json"` in their code
- Use the inefficient/obscure syntax `new JsonRequestSettings().ContentType`

This change exposes a new `static readonly` string `JsonRequestSettings.JsonContentType` for this constant, and updates string literals within the library to reference this new field instead.
