### PR TITLE
NuGet updates

### DIFF
--- a/src/SimpleRestServices/SimpleRestServices.nuspec
+++ b/src/SimpleRestServices/SimpleRestServices.nuspec
@@ -14,4 +14,7 @@
     <copyright>Copyright © JSI Studios 2013</copyright>
     <tags>REST REST_client</tags>
   </metadata>
+  <files>
+    <file src="..\Documentation\Api\SimpleRESTServices.xml" target="lib\net40"/>
+  </files>
 </package>


### PR DESCRIPTION
## Big change (with release build instructions)

Explicitly reference the _transformed_ XML documentation file which Sandcastle produces, instead of simply including the default one produced by the .NET compiler. This operation replaces tags like `<inheritdoc/>` which appear in the original source with the referenced documentation so IntelliSense features provide the complete and accurate documentation to users. This _also_ means you must build the Sandcastle project before you can create the NuGet package, and the NuGet package will only include up-to-date xml documentation if the projects are built in the following order.
1. Build the `SimpleRestServices` project in the Release configuration.
2. Build the Sandcastle project (`src/Documentation/Documentation.shfbproj`) in the Release configuration.
3. Build the NuGet package with the following command.
   
   ```
   NuGet.exe pack SimpleRestServices.csproj -Prop Configuration=Release -Symbols
   ```
## Smaller changes
- Updated author field to use your actual name instead of username
- Updated copyright field to include "JSI Studios" (now matches the `[AssemblyCopyright]` attribute value)
- Added `xmlns` declaration to the nuspec file
