### PR TITLE
Add property RequestSettings.ConnectionLimit

### DIFF
--- a/src/SimpleRestServices/Client/RequestSettings.cs
+++ b/src/SimpleRestServices/Client/RequestSettings.cs
@@ -148,6 +148,17 @@ namespace JSIStudios.SimpleRESTServices.Client
         public bool AllowZeroContentLength { get; set; }
 
         /// <summary>
+        /// Gets or sets the maximum number of connections allowed on the <see cref="ServicePoint"/> object
+        /// used for the request. If the value is <c>null</c>, the connection limit value for the
+        /// <see cref="ServicePoint"/> object is not altered.
+        /// </summary>
+        public int? ConnectionLimit
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="RequestSettings"/> class with the default values.
         /// </summary>
         public RequestSettings()

--- a/src/SimpleRestServices/Client/RestServiceBase.cs
+++ b/src/SimpleRestServices/Client/RestServiceBase.cs
@@ -417,6 +417,9 @@ namespace JSIStudios.SimpleRESTServices.Client
                     if(settings.ContentLength > 0 || settings.AllowZeroContentLength)
                         req.ContentLength = settings.ContentLength;
 
+                    if (settings.ConnectionLimit != null)
+                        req.ServicePoint.ConnectionLimit = settings.ConnectionLimit.Value;
+
                     req.Timeout = (int)settings.Timeout.TotalMilliseconds;
 
                     if (!string.IsNullOrWhiteSpace(settings.UserAgent))


### PR DESCRIPTION
This property allows users to specify the connection limit for individual requests, instead of relying on `ServicePointManager.DefaultConnectionLimit` or the configuration file.
