### PR TITLE
Exposing the AllowAutoRedirect property of System.Net.HttpWebRequest to callers of this library.

### DIFF
--- a/src/SimpleRestServices/Client/RequestSettings.cs
+++ b/src/SimpleRestServices/Client/RequestSettings.cs
@@ -159,6 +159,17 @@ namespace JSIStudios.SimpleRESTServices.Client
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the request should follow redirection responses.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the request should follow redirection responses; otherwise, <c>false</c>.
+        /// </value>
+        /// <remarks>
+        /// See http://msdn.microsoft.com/en-us/library/system.net.httpwebrequest.allowautoredirect%28v=vs.110%29.aspx
+        /// </remarks>
+        public bool AllowAutoRedirect { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="RequestSettings"/> class with the default values.
         /// </summary>
         public RequestSettings()
@@ -167,6 +178,7 @@ namespace JSIStudios.SimpleRESTServices.Client
             RetryDelay = TimeSpan.Zero;
             Non200SuccessCodes = null;
             Timeout = TimeSpan.FromMilliseconds(100000);
+            AllowAutoRedirect = true;
         }
     }
 }

--- a/src/SimpleRestServices/Client/RestServiceBase.cs
+++ b/src/SimpleRestServices/Client/RestServiceBase.cs
@@ -416,6 +416,7 @@ namespace JSIStudios.SimpleRESTServices.Client
                     req.Method = method.ToString();
                     req.ContentType = settings.ContentType;
                     req.Accept = settings.Accept;
+                    req.AllowAutoRedirect = settings.AllowAutoRedirect;
                     if(settings.ContentLength > 0 || settings.AllowZeroContentLength)
                         req.ContentLength = settings.ContentLength;
 


### PR DESCRIPTION
### Summary
- Allowing callers to pass AllowAutoRedirect values. 
  - The default for this value is `true` in `System.Net.HttpWebRequest` so that behavior was modeled. This edit is needed for the case where a POST is performed and the web server responds with a 301. `HttpWebRequest` behavior when auto redirect is `true` retries the attempt as a GET. It will allow our code to be cleaner if we could have this 301 return from the library so we can update our data to have the new url and then re-try the POST manually.
